### PR TITLE
WIP: Improve optional parameter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@ Run the `installCatalog.sh` script to install the catalog.
 $ OPENWHISK_HOME=<path_to_openwhisk> ./packages/installCatalog.sh
  ```
 
-This script needs the API hostname to target and the authentication credentials for administration account. These values can be set explicitly using the `API_HOST` and `CATALOG_AUTH_KEY` environment parameters.
+This script needs the API hostname to target, path to wsk CLI binary and authentication credentials for administration account. These values can be set explicitly using the `API_HOST`, `CLI_PATH` and `CATALOG_AUTH_KEY` environment parameters.
 
 *If `API_HOST` is not set, the script looks for the `edge.host` value in the `whisk.properties` file under `$OPENWHISK_HOME`.*
+
+*If `CLI_PATH` is not set, the script checks for the `bin/wsk` binary under `$OPENWHISK_HOME`.*
 
 *If `CATALOG_AUTH_KEY` is not set, the script looks for the contents of the `ansible/files/auth.whisk.system` file under `$OPENWHISK_HOME`.*
 

--- a/README.md
+++ b/README.md
@@ -19,15 +19,17 @@ for information about how to browse the catalog by using the command line tool.
 
 ### Install openwhisk-catalog
 
-We should be able to run the script installCatalog.sh to install the catalog like:
+Run the `installCatalog.sh` script to install the catalog.
 
-```
-./installCatalog.sh [catalog_auth_key] [api_host]
-```
+ ```
+$ OPENWHISK_HOME=<path_to_openwhisk> ./packages/installCatalog.sh
+ ```
 
-The first argument `catalog_auth_key`, defines the secret key used to authenticate the openwhisk
-service. The second argument `api_host`, determines the location, where the openwhisk edge host is running,
-in the format of IP or hostname.
+This script needs the API hostname to target and the authentication credentials for administration account. These values can be set explicitly using the `API_HOST` and `CATALOG_AUTH_KEY` environment parameters.
+
+*If `API_HOST` is not set, the script looks for the `edge.host` value in the `whisk.properties` file under `$OPENWHISK_HOME`.*
+
+*If `CATALOG_AUTH_KEY` is not set, the script looks for the contents of the `ansible/files/auth.whisk.system` file under `$OPENWHISK_HOME`.*
 
 ## Existing packages in catalog
 

--- a/packages/installCatalog.sh
+++ b/packages/installCatalog.sh
@@ -8,7 +8,7 @@
 SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
 OPENWHISK_HOME=${OPENWHISK_HOME:-$SCRIPTDIR/../../openwhisk}
 
-source "$SCRIPTDIR/validateParameter.sh" $1 $2 $3
+source "$SCRIPTDIR/validateParameter.sh"
 : ${WHISK_SYSTEM_AUTH:?"WHISK_SYSTEM_AUTH is not configured. Please input the correctly parameter: CATALOG_AUTH_KEY"}
 : ${WHISK_API_HOST:?"WHISK_API_HOST is not configured. Please input the correctly parameter: API_HOST"}
 : ${WHISK_CLI_PATH:?"WHISK_CLI_PATH is not configured. Please input the correctly parameter: cli_path"}

--- a/packages/installCatalog.sh
+++ b/packages/installCatalog.sh
@@ -11,7 +11,7 @@ OPENWHISK_HOME=${OPENWHISK_HOME:-$SCRIPTDIR/../../openwhisk}
 source "$SCRIPTDIR/validateParameter.sh"
 : ${WHISK_SYSTEM_AUTH:?"WHISK_SYSTEM_AUTH is not configured. Please input the correctly parameter: CATALOG_AUTH_KEY"}
 : ${WHISK_API_HOST:?"WHISK_API_HOST is not configured. Please input the correctly parameter: API_HOST"}
-: ${WHISK_CLI_PATH:?"WHISK_CLI_PATH is not configured. Please input the correctly parameter: cli_path"}
+: ${WHISK_CLI_PATH:?"WHISK_CLI_PATH is not configured. Please input the correctly parameter: CLI_PATH"}
 
 source "$SCRIPTDIR/util.sh"
 

--- a/packages/validateParameter.sh
+++ b/packages/validateParameter.sh
@@ -5,7 +5,9 @@
 
 # The first argument is the catalog authentication key, which can be passed via either
 # a file or the key itself.
-CATALOG_AUTH_KEY=${1:-"$OPENWHISK_HOME/ansible/files/auth.whisk.system"}
+if [ -z "$CATALOG_AUTH_KEY" ]; then
+    CATALOG_AUTH_KEY="$OPENWHISK_HOME/ansible/files/auth.whisk.system"
+fi
 
 # If the auth key file exists, read the key in the file. Otherwise, take the
 # first argument as the key itself.
@@ -19,7 +21,6 @@ export WHISK_SYSTEM_AUTH=$CATALOG_AUTH_KEY
 
 # The api host is passed as the second argument. If it is not provided, take the edge
 # host from the whisk properties file.
-API_HOST=$2
 if [ -z "$API_HOST" ]; then
     WHISKPROPS_FILE="$OPENWHISK_HOME/whisk.properties"
     if [ ! -f "$WHISKPROPS_FILE" ]; then
@@ -35,5 +36,8 @@ export WHISK_API_HOST=$API_HOST
 
 # The CLI path is passed as the third argument. If it is not provided, use
 # "$OPENWHISK_HOME/bin/wsk" as the default value.
-cli_path=${3:-"$OPENWHISK_HOME/bin/wsk"}
-export WHISK_CLI_PATH=$cli_path
+if [ -z "$CLI_PATH" ]; then
+    CLI_PATH="$OPENWHISK_HOME/bin/wsk"
+fi
+
+export WHISK_CLI_PATH=$CLI_PATH


### PR DESCRIPTION
I've hit a bug where the script doesn't allow optional parameters, even though the script supports this.

If the `CATALOG_AUTH_KEY` parameter is missing, the script will extract the value from:
```
-CATALOG_AUTH_KEY=${1:-"$OPENWHISK_HOME/ansible/files/auth.whisk.system"}
```

However, if I miss this parameter on the command-line, it assumes there are only two parameters, not three and fails. If I pass an empty string to force a null parameter, this doesn't pass through to the `source "$SCRIPTDIR/validateParameter.sh" $1 $2 $3` correctly. 

I made an attempt to fix this by using environment variables for all parameters as they are all optional.