### PR TITLE
JIRA feed package for Openwhisk catalog 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 # Openwhisk Catalog
 
-[![Build Status](https://travis-ci.org/prabhashthere/incubator-openwhisk-catalog.svg?branch=master)](https://travis-ci.org/prabhashthere/incubator-openwhisk-catalog)
+[![Build Status](https://travis-ci.org/apache/incubator-openwhisk-catalog.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-catalog)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 
 This openwhisk-catalog maintains the package catalogs of openwhisk. In OpenWhisk, the catalog

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 This openwhisk-catalog maintains the package catalogs of openwhisk. In OpenWhisk, the catalog
 of packages gives you an easy way to enhance your app with useful capabilities, and to access
 external services in the ecosystem. Examples of external services that are OpenWhisk-enabled
-include IBM Watson API, the Weather Company, Slack, and GitHub.system packages and sample packages.
+include IBM Watson API, the Weather Company, JIRA, Slack, and GitHub.system packages and sample packages.
 
 The catalog is available as packages in the `/whisk.system` namespace. See [Browsing packages](https://github.com/openwhisk/openwhisk/blob/master/docs/packages.md#browsing-packages)
 for information about how to browse the catalog by using the command line tool.
@@ -60,6 +60,7 @@ in the format of IP or hostname. The third argument `cli_path` is the full path 
 | [/whisk.system/watson-textToSpeech](./packages/watson-textToSpeech/README.md) | Package to convert text into speech|
 | [/whisk.system/weather](./packages/weather/README.md) | Services from the Weather Company Data for IBM Bluemix API|
 | [/whisk.system/websocket](./packages/websocket/README.md) | Package to send messages to Web Socket server|
+| [/whisk.system/jira](./packages/jira/README.md) | offers a convenient way to use the [JIRA APIs](https://developer.atlassian.com/server/jira/platform/rest-apis/). |
 
 <!--
 TODO: place holder until we have a README for samples

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 # Openwhisk Catalog
 
-[![Build Status](https://travis-ci.org/apache/incubator-openwhisk-catalog.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-catalog)
+[![Build Status](https://travis-ci.org/prabhashthere/incubator-openwhisk-catalog.svg?branch=master)](https://travis-ci.org/prabhashthere/incubator-openwhisk-catalog)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 
 This openwhisk-catalog maintains the package catalogs of openwhisk. In OpenWhisk, the catalog

--- a/packages/installCatalog.sh
+++ b/packages/installCatalog.sh
@@ -35,6 +35,7 @@ echo Installing OpenWhisk packages
 runPackageInstallScript "$SCRIPTDIR" installCombinators.sh
 runPackageInstallScript "$SCRIPTDIR" installGit.sh
 runPackageInstallScript "$SCRIPTDIR" installSlack.sh
+runPackageInstallScript "$SCRIPTDIR" installJira.sh
 runPackageInstallScript "$SCRIPTDIR" installSystem.sh
 runPackageInstallScript "$SCRIPTDIR" installWatson.sh
 runPackageInstallScript "$SCRIPTDIR" installWeather.sh

--- a/packages/installJira.sh
+++ b/packages/installJira.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# use the command line interface to install JIRA package.
+#
+: ${WHISK_SYSTEM_AUTH:?"WHISK_SYSTEM_AUTH must be set and non-empty"}
+AUTH_KEY=$WHISK_SYSTEM_AUTH
+
+SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
+PACKAGE_HOME=$SCRIPTDIR
+source "$PACKAGE_HOME/util.sh"
+
+echo Installing Jira package.
+
+createPackage jira \
+    -a description "Package which contains actions and feeds to interact with JIRA"
+
+waitForAll
+
+install "$PACKAGE_HOME/jira/jirafeed.js" \
+    jira/jirafeed \
+    -a feed true \
+    -a description 'Creates a webhook on JIRA to be notified on selected changes' \
+    -a parameters '[ {"name":"username", "required":true, "bindTime":true, "description": "Your JIRA username"}, {"name":"siteName", "required":true, "bindTime":true, "description": "first part of your website domain name"}, {"name":"accessToken", "required":true, "bindTime":true, "description": "A webhook or personal token", "doclink": "https://id.atlassian.com/manage/api-tokens"},{"name":"webhookName", "bindTime":true, "description": "A name for the JIRA webhook"},{"name":"force_http", "bindTime":true, "description": "do you want to skip ssl certificate"},{"name":"events", "required":true, "description": "A comma-separated list"} ]' \
+    -a sampleInput '{"username":"myUserName", "siteName":"abcCompany", "accessToken":"123ABCXYZ", "webhookName":"myFirst", "force_http":"true", "events":"jira:issue_created,jira:issue_updated,jira:issue_deleted"}'
+
+waitForAll
+
+echo JIRA package ERRORS = $ERRORS
+exit $ERRORS

--- a/packages/jira/README.md
+++ b/packages/jira/README.md
@@ -1,0 +1,69 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
+# Using the JIRA package
+
+The /whisk.system/jira package offers a convenient way to use the JIRA APIs.
+
+The package includes the following feed:
+
+| Entity | Type | Parameters | Description |
+| --- | --- | --- | --- |
+| `/whisk.system/jira` | package | username, siteName, force_http, accessToken | Interact with the JIRA API |
+| `/whisk.system/jira/jirafeed` | feed | events, username,  siteName, force_http, accessToken | Fire trigger events on JIRA activity |
+
+
+Creating a package binding with the username, siteName, force_http and accessToken values is suggested. With binding, you don't need to specify the values each time that you use the feed in the package.
+Firing a trigger event with JIRA activity
+
+The /whisk.system/jira/jirafeed feed configures a service to fire a trigger when there is activity in a specified JIRA site. The parameters are as follows:
+
+- `username`: The user name of the atlassian account.
+- `siteName`: Your atlassian site name.
+- `accessToken`: Your JIRA personal access token.
+- `webhookName`: A name for the JIRA webhook (optional).
+- `force_http`: 'true' or 'false' (if you want to use http protocol to bypass SSL verification).
+- `events`: The [JIRA event type](https://developer.atlassian.com/server/jira/platform/webhooks/) of interest.
+
+The following is an example of creating a trigger that will be fired each time that there is a new issue created, deleted or modified in your atlassian site.
+
+1. Generate a JIRA [personal access token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html).
+
+
+The access token will be used in the next step.
+
+2. Create a package binding that is configured for your GitHub repository and with your access token.
+
+```
+wsk package bind /whisk.system/jira myJira \
+  --param username mike@anymail.com \
+  --param siteName mike.atlassian.net \
+  --param webhookName my_first_webhook \
+  --param force_http false \
+  --param accessToken aaaaa1111a1a1a1a1a111111aaaaaa1111aa1a1a
+```
+
+3. Create a trigger for the GitHub `push` event type by using your `myJira/jirafeed` feed.
+
+
+```
+wsk trigger create myJiraTrigger --feed myJira/jirafeed --param events jira:issue_created,jira:issue_deleted 
+```
+  
+Creating deleting or updating an issue causes the trigger to be fired by the webhook. If there is a rule that matches the trigger, then the associated action will be invoked. The action receives the JIRA webhook payload as an input parameter. Each JIRA webhook event has a similar JSON schema, but is a unique payload object that is determined by its event type. For more information about the payload content, see the [JIRA API documentation](https://developer.atlassian.com/server/jira/platform/rest-apis/).

--- a/packages/jira/README.md
+++ b/packages/jira/README.md
@@ -76,5 +76,5 @@ wsk package bind /whisk.system/jira myJira \
 ```
 wsk trigger create myJiraTrigger --feed myJira/jirafeed --param events jira:issue_created,jira:issue_deleted 
 ```
-  
+
 Creating deleting or updating an issue causes the trigger to be fired by the webhook. If there is a rule that matches the trigger, then the associated action will be invoked. The action receives the JIRA webhook payload as an input parameter. Each JIRA webhook event has a similar JSON schema, but is a unique payload object that is determined by its event type. For more information about the payload content, see the [JIRA API documentation](https://developer.atlassian.com/server/jira/platform/rest-apis/).

--- a/packages/jira/README.md
+++ b/packages/jira/README.md
@@ -47,7 +47,8 @@ The following is an example of creating a trigger that will be fired each time t
 
 ```
 WHISK_CLI_PATH=/home/mike/openwhisk/bin/wsk \
-WHISK_API_HOST=100.100.100.100 \ WHISK_SYSTEM_AUTH=789c46b1-71f6-4ed5-8c54-816aa4f8c502:abczO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP \
+WHISK_API_HOST=100.100.100.100 \
+WHISK_SYSTEM_AUTH=789c46b1-71f6-4ed5-8c54-816aa4f8c502:abczO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP \
 OPENWHISK_HOME=/home/mike/openwhisk \
 ./installJira.sh
 ```

--- a/packages/jira/README.md
+++ b/packages/jira/README.md
@@ -25,11 +25,11 @@ The package includes the following feed:
 
 | Entity | Type | Parameters | Description |
 | --- | --- | --- | --- |
-| `/whisk.system/jira` | package | username, siteName, force_http, accessToken | Interact with the JIRA API |
-| `/whisk.system/jira/jirafeed` | feed | events, username,  siteName, force_http, accessToken | Fire trigger events on JIRA activity |
+| `/whisk.system/jira` | package | username, siteName, forceHttp, accessToken | Interact with the JIRA API |
+| `/whisk.system/jira/jirafeed` | feed | events, username,  siteName, forceHttp, accessToken | Fire trigger events on JIRA activity |
 
 
-Creating a package binding with the username, siteName, force_http and accessToken values is suggested. With binding, you don't need to specify the values each time that you use the feed in the package.
+Creating a package binding with the username, siteName, forceHttp and accessToken values is suggested. With binding, you don't need to specify the values each time that you use the feed in the package.
 Firing a trigger event with JIRA activity
 
 The /whisk.system/jira/jirafeed feed configures a service to fire a trigger when there is activity in a specified JIRA site. The parameters are as follows:
@@ -38,7 +38,7 @@ The /whisk.system/jira/jirafeed feed configures a service to fire a trigger when
 - `siteName`: Your atlassian site name.
 - `accessToken`: Your JIRA personal access token.
 - `webhookName`: A name for the JIRA webhook (optional).
-- `force_http`: 'true' or 'false' (if you want to use http protocol to bypass SSL verification).
+- `forceHttp`: 'true' or 'false' (if you want to use http protocol to bypass SSL verification).
 - `events`: The [JIRA event type](https://developer.atlassian.com/server/jira/platform/webhooks/) of interest.
 
 The following is an example of creating a trigger that will be fired each time that there is a new issue created, deleted or modified in your atlassian site.
@@ -66,7 +66,7 @@ wsk package bind /whisk.system/jira myJira \
   --param username mike@anymail.com \
   --param siteName mike.atlassian.net \
   --param webhookName my_first_webhook \
-  --param force_http false \
+  --param forceHttp false \
   --param accessToken aaaaa1111a1a1a1a1a111111aaaaaa1111aa1a1a
 ```
 

--- a/packages/jira/README.md
+++ b/packages/jira/README.md
@@ -43,12 +43,22 @@ The /whisk.system/jira/jirafeed feed configures a service to fire a trigger when
 
 The following is an example of creating a trigger that will be fired each time that there is a new issue created, deleted or modified in your atlassian site.
 
-1. Generate a JIRA [personal access token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html).
+1. Install the JIRA package (If you haven't installed the Openwhisk catalog yet)
+
+```
+WHISK_CLI_PATH=/home/mike/openwhisk/bin/wsk \
+WHISK_API_HOST=100.100.100.100 \ WHISK_SYSTEM_AUTH=789c46b1-71f6-4ed5-8c54-816aa4f8c502:abczO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP \
+OPENWHISK_HOME=/home/mike/openwhisk \
+./installJira.sh
+```
+
+
+2. Generate a JIRA [personal access token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html).
 
 
 The access token will be used in the next step.
 
-2. Create a package binding that is configured for your GitHub repository and with your access token.
+3. Create a package binding that is configured for your GitHub repository and with your access token.
 
 ```
 wsk package bind /whisk.system/jira myJira \
@@ -59,7 +69,7 @@ wsk package bind /whisk.system/jira myJira \
   --param accessToken aaaaa1111a1a1a1a1a111111aaaaaa1111aa1a1a
 ```
 
-3. Create a trigger for the GitHub `push` event type by using your `myJira/jirafeed` feed.
+4. Create a trigger for the GitHub `push` event type by using your `myJira/jirafeed` feed.
 
 
 ```

--- a/packages/jira/README.md
+++ b/packages/jira/README.md
@@ -74,7 +74,7 @@ wsk package bind /whisk.system/jira myJira \
 
 
 ```
-wsk trigger create myJiraTrigger --feed myJira/jirafeed --param events jira:issue_created,jira:issue_deleted 
+wsk trigger create myJiraTrigger --feed myJira/jirafeed --param events jira:issue_created,jira:issue_deleted
 ```
 
 Creating deleting or updating an issue causes the trigger to be fired by the webhook. If there is a rule that matches the trigger, then the associated action will be invoked. The action receives the JIRA webhook payload as an input parameter. Each JIRA webhook event has a similar JSON schema, but is a unique payload object that is determined by its event type. For more information about the payload content, see the [JIRA API documentation](https://developer.atlassian.com/server/jira/platform/rest-apis/).

--- a/packages/jira/jirafeed.js
+++ b/packages/jira/jirafeed.js
@@ -1,0 +1,181 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor
+// license agreements; and to You under the Apache License, Version 2.0.
+
+var request = require('request');
+
+/**
+ *  Feed to create a webhook on JIRA
+ *
+ *  @param {object} params - information about the trigger
+ *  @param {string} siteName - atlassian website to create webhook (enter only the first part of the site name)
+ *  @param {string} username - atlassian username
+ *  @param {string} force_http - 'true' or 'false'
+ *  @param {string} accessToken - atlassian access token
+ *  @param {string} events - list of the events the webhook should fire on
+ *  @return {object} whisk async
+ */
+function main(params) {
+    var username = params.username;
+    var accessToken = params.accessToken;
+    var siteName = params.siteName;
+    var webhookName = params.webhookName || "My JIRA Webhook";
+    var force_http = (JSON.stringify(params.force_http) === 'true' || JSON.stringify(params.force_http) === 'True');
+    var authenticationHeader = "Basic " + new Buffer.from(username + ":" + accessToken).toString("base64");
+
+    var lifecycleEvent = params.lifecycleEvent;
+    var triggerName = params.triggerName.split("/");
+
+    // URL of the whisk system. The calls of JIRA will go here.
+    var urlHost = require('url').parse(process.env.__OW_API_HOST);
+
+    if (force_http) {
+        var whiskCallbackUrl = 'http://' + process.env.__OW_API_KEY + "@" + urlHost.host.substring(0, urlHost.host.length - 4) + '/api/v1/namespaces/'
+            + encodeURIComponent(triggerName[1]) + '/triggers/' + encodeURIComponent(triggerName[2]);
+    }
+    else {
+        var whiskCallbackUrl = urlHost.protocol + '//' + process.env.__OW_API_KEY + "@" + urlHost.host + '/api/v1/namespaces/'
+            + encodeURIComponent(triggerName[1]) + '/triggers/' + encodeURIComponent(triggerName[2]);
+    }
+    // The URL to create the webhook on JIRA
+    var myJiraUrl = 'https://' + siteName + '/rest/webhooks/1.0/webhook';
+
+    if (lifecycleEvent === "CREATE") {
+        var events = params.events.split(',');
+
+        var body = {
+            name: webhookName,
+            url: whiskCallbackUrl,
+            events: events,
+            excludeBody: false
+        };
+
+        var options = {
+            //hostname: jiraHostUrl,
+            //path: '/rest/webhooks/1.0/webhook',
+            url: myJiraUrl,
+            method: 'POST',
+            body: JSON.stringify(body),
+            headers: {
+                'Authorization': authenticationHeader,
+                'Content-Type': 'application/json',
+                'User-Agent': 'whisk'
+            }
+        };
+
+        var promise = new Promise(function (resolve, reject) {
+            request(options, function (error, response, body) {
+                if (error) {
+                    console.log(error);
+                    reject({
+                        response: response,
+                        error: error,
+                        body: body
+                    });
+                } else {
+                    console.log("Status code: " + response.statusCode);
+
+                    if (response.statusCode >= 400) {
+                        console.log("Response from JIRA: " + body);
+                        reject({
+                            statusCode: response.statusCode,
+                            response: body
+                        });
+                    } else {
+                        resolve({response: body});
+                        console.log("Webhook created successfully");
+                    }
+                }
+            });
+        });
+
+        return promise;
+
+
+    } else if (lifecycleEvent === "DELETE") {
+
+        //list all the existing webhooks first.
+        var deleteOptions = {
+            //hostname : jiraHostUrl,
+            //path : '/rest/webhooks/1.0/webhook',
+            url: myJiraUrl,
+            method: 'GET',
+            headers: {
+                'Authorization': authenticationHeader,
+                'Content-Type': 'application/json',
+                'User-Agent': 'whisk'
+            }
+        };
+
+
+        var deletePromise = new Promise(function (resolve, reject) {
+            request(deleteOptions, function (error, response, body) {
+                // the URL that comes back from JIRA does not include auth info
+                var foundWebhookToDelete = false;
+
+                if (error) {
+                    console.log(error);
+                    reject({
+                        response: response,
+                        error: error,
+                        body: body
+                    });
+                } else {
+                    bodyObj = JSON.parse(body);
+                    for (var i = 0; i < bodyObj.length; i++) {
+                        if (decodeURI(bodyObj[i].url) === whiskCallbackUrl) {
+                            foundWebhookToDelete = true;
+                            console.log('DELETE Webhook with callBackURL: ' + bodyObj[i].url);
+                            var urlArray = bodyObj[i].self.split('/');
+                            var webhookId = urlArray[urlArray.length - 1];
+
+                            var options = {
+                                method: 'DELETE',
+                                url: bodyObj[i].self,
+                                headers: {
+                                    'Content-Type': 'application/json',
+                                    'Authorization': authenticationHeader,
+                                    'User-Agent': 'whisk'
+                                }
+                            };
+
+
+                            request(options, function (error, response, body) {
+                                if (error) {
+                                    console.log(error);
+                                    reject({
+                                        response: response,
+                                        error: error,
+                                        body: body
+                                    });
+                                } else {
+                                    console.log("Status code: " + response.statusCode);
+                                    if (response.statusCode >= 400) {
+                                        console.log("Response from JIRA: " + body);
+                                        if (response.statusCode === 404) {
+                                            console.log('Please ensure your accessToken is authorized to delete webhooks.');
+                                        }
+
+                                        reject({
+                                            statusCode: response.statusCode,
+                                            response: body
+                                        });
+                                    } else {
+                                        resolve({response: body});
+                                        console.log("Webhook deleted successfully");
+                                    }
+                                }
+                            });
+                        }
+                    }
+
+                    if (!foundWebhookToDelete) {
+                        reject('No related webhooks found for this trigger');
+                    }
+                }
+            });
+        });
+
+        return deletePromise;
+
+    }
+}

--- a/packages/jira/jirafeed.js
+++ b/packages/jira/jirafeed.js
@@ -27,14 +27,13 @@ function main(params) {
 
     // URL of the whisk system. The calls of JIRA will go here.
     var urlHost = require('url').parse(process.env.__OW_API_HOST);
+    var whiskCallbackUrl;
 
     if (forceHttp) {
-        var whiskCallbackUrl = 'http://' + process.env.__OW_API_KEY + "@" + urlHost.host.substring(0, urlHost.host.length - 4) + '/api/v1/namespaces/'
-            + encodeURIComponent(triggerName[1]) + '/triggers/' + encodeURIComponent(triggerName[2]);
+        whiskCallbackUrl = 'http://' + process.env.__OW_API_KEY + "@" + urlHost.host.substring(0, urlHost.host.length - 4) + '/api/v1/namespaces/' + encodeURIComponent(triggerName[1]) + '/triggers/' + encodeURIComponent(triggerName[2]);
     }
     else {
-        var whiskCallbackUrl = urlHost.protocol + '//' + process.env.__OW_API_KEY + "@" + urlHost.host + '/api/v1/namespaces/'
-            + encodeURIComponent(triggerName[1]) + '/triggers/' + encodeURIComponent(triggerName[2]);
+        whiskCallbackUrl = urlHost.protocol + '//' + process.env.__OW_API_KEY + "@" + urlHost.host + '/api/v1/namespaces/' + encodeURIComponent(triggerName[1]) + '/triggers/' + encodeURIComponent(triggerName[2]);
     }
     // The URL to create the webhook on JIRA
     var myJiraUrl = 'https://' + siteName + '/rest/webhooks/1.0/webhook';
@@ -113,7 +112,7 @@ function main(params) {
                         body: body
                     });
                 } else {
-                    bodyObj = JSON.parse(body);
+                    var bodyObj = JSON.parse(body);
                     for (var i = 0; i < bodyObj.length; i++) {
                         if (decodeURI(bodyObj[i].url) === whiskCallbackUrl) {
                             foundWebhookToDelete = true;

--- a/packages/jira/jirafeed.js
+++ b/packages/jira/jirafeed.js
@@ -78,7 +78,6 @@ function main(params) {
                             response: body
                         });
                     } else {
-                        console.log("Webhook created successfully");
                         resolve({response: body});
                     }
                 }
@@ -152,7 +151,6 @@ function main(params) {
                                             response: body
                                         });
                                     } else {
-                                        console.log("Webhook deleted successfully");
                                         resolve({response: body});
                                     }
                                 }

--- a/packages/jira/jirafeed.js
+++ b/packages/jira/jirafeed.js
@@ -9,7 +9,7 @@ var request = require('request');
  *  @param {object} params - information about the trigger
  *  @param {string} siteName - atlassian website to create webhook (enter only the first part of the site name)
  *  @param {string} username - atlassian username
- *  @param {string} force_http - 'true' or 'false'
+ *  @param {string} forceHttp - 'true' or 'false'
  *  @param {string} accessToken - atlassian access token
  *  @param {string} events - list of the events the webhook should fire on
  *  @return {object} whisk async
@@ -19,7 +19,7 @@ function main(params) {
     var accessToken = params.accessToken;
     var siteName = params.siteName;
     var webhookName = params.webhookName || "My JIRA Webhook";
-    var force_http = (JSON.stringify(params.force_http) === 'true' || JSON.stringify(params.force_http) === 'True');
+    var forceHttp = (JSON.stringify(params.forceHttp) === 'true' || JSON.stringify(params.forceHttp) === 'True');
     var authenticationHeader = "Basic " + new Buffer.from(username + ":" + accessToken).toString("base64");
 
     var lifecycleEvent = params.lifecycleEvent;
@@ -28,7 +28,7 @@ function main(params) {
     // URL of the whisk system. The calls of JIRA will go here.
     var urlHost = require('url').parse(process.env.__OW_API_HOST);
 
-    if (force_http) {
+    if (forceHttp) {
         var whiskCallbackUrl = 'http://' + process.env.__OW_API_KEY + "@" + urlHost.host.substring(0, urlHost.host.length - 4) + '/api/v1/namespaces/'
             + encodeURIComponent(triggerName[1]) + '/triggers/' + encodeURIComponent(triggerName[2]);
     }
@@ -63,7 +63,6 @@ function main(params) {
         var promise = new Promise(function (resolve, reject) {
             request(options, function (error, response, body) {
                 if (error) {
-                    console.log(error);
                     reject({
                         response: response,
                         error: error,
@@ -79,8 +78,8 @@ function main(params) {
                             response: body
                         });
                     } else {
-                        resolve({response: body});
                         console.log("Webhook created successfully");
+                        resolve({response: body});
                     }
                 }
             });
@@ -109,7 +108,6 @@ function main(params) {
                 var foundWebhookToDelete = false;
 
                 if (error) {
-                    console.log(error);
                     reject({
                         response: response,
                         error: error,
@@ -121,8 +119,6 @@ function main(params) {
                         if (decodeURI(bodyObj[i].url) === whiskCallbackUrl) {
                             foundWebhookToDelete = true;
                             console.log('DELETE Webhook with callBackURL: ' + bodyObj[i].url);
-                            var urlArray = bodyObj[i].self.split('/');
-                            var webhookId = urlArray[urlArray.length - 1];
 
                             var options = {
                                 method: 'DELETE',
@@ -156,8 +152,8 @@ function main(params) {
                                             response: body
                                         });
                                     } else {
-                                        resolve({response: body});
                                         console.log("Webhook deleted successfully");
+                                        resolve({response: body});
                                     }
                                 }
                             });

--- a/packages/jira/jirafeed.js
+++ b/packages/jira/jirafeed.js
@@ -50,8 +50,6 @@ function main(params) {
         };
 
         var options = {
-            //hostname: jiraHostUrl,
-            //path: '/rest/webhooks/1.0/webhook',
             url: myJiraUrl,
             method: 'POST',
             body: JSON.stringify(body),
@@ -95,8 +93,6 @@ function main(params) {
 
         //list all the existing webhooks first.
         var deleteOptions = {
-            //hostname : jiraHostUrl,
-            //path : '/rest/webhooks/1.0/webhook',
             url: myJiraUrl,
             method: 'GET',
             headers: {

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -36,6 +36,7 @@ tasks.withType(Test) {
 task testWithoutCredentials(type: Test) {
     exclude 'packages/watson/**'
     exclude 'packages/slack/**'
+    exclude 'packages/jira/**'
     exclude 'packages/weather/**'
 }
 

--- a/tests/src/test/scala/packages/jira/JiraTest.scala
+++ b/tests/src/test/scala/packages/jira/JiraTest.scala
@@ -1,0 +1,57 @@
+
+package packages.slack
+
+import org.junit.runner.RunWith
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.junit.JUnitRunner
+import common._
+import spray.json.DefaultJsonProtocol._
+import spray.json._
+
+@RunWith(classOf[JUnitRunner])
+class JiraTests extends TestHelpers with WskTestHelpers with BeforeAndAfterAll {
+  implicit val wskprops = WskProps()
+  val wsk = new Wsk()
+
+  val credentials = TestUtils.getCredentials("slack_webhook")
+  val username = credentials.get("username").getAsString()
+  val siteName = credentials.get("siteName").getAsString()
+  val accessToken = credentials.get("accessToken").getAsString()
+  val webhookName = credentials.get("webhookName").getAsString()
+  val force_http = credentials.get("force_http").getAsString()
+  val events = credentials.get("events").getAsString().split(',') //split this
+  val myJiraFeed = credentials.get("channel").getAsString()
+
+  "Jira Package" should "print the webhook created on JIRA" in {
+    val run = wsk.trigger.create(myJiraFeed, Map(
+      "username" -> username.toJson,
+      "siteName" -> siteName.toJson,
+      "accessToken" -> accessToken.toJson,
+      "webhookName" -> webhookName.toJson,
+      "force_http" -> force_http.toJson,
+      "events" -> events.split(,)toJson))   //can be a syntax error
+    withActivation(wsk.activation, run) {
+      activation =>
+        activation.response.success shouldBe true
+        val logs = activation.logs.get.toString
+        logs should include("Webhook created successfully")
+    }
+  }
+
+  "Jira Package" should "print the webhook deleted on JIRA" in {
+    val run = wsk.trigger.delete(myJiraTrigger, Map(
+      "username" -> username.toJson,
+      "siteName" -> siteName.toJson,
+      "accessToken" -> accessToken.toJson,
+      //        "webhookName" -> webhookName.toJson,
+      "force_http" -> force_http.toJson))
+    //        "events" -> events.toJson))                       //this should be splitted
+    withActivation(wsk.activation, run) {
+      activation =>
+        activation.response.success shouldBe true
+        val logs = activation.logs.get.toString
+        logs should include("Webhook deleted successfully")
+    }
+  }
+
+}

--- a/tests/src/test/scala/packages/jira/JiraTest.scala
+++ b/tests/src/test/scala/packages/jira/JiraTest.scala
@@ -21,7 +21,6 @@ class JiraTests extends TestHelpers with WskTestHelpers with BeforeAndAfterAll {
   val force_http = credentials.get("force_http").getAsString()
   val triggerName = "/_/" + credentials.get("triggerName").getAsString()
   val events = credentials.get("events").getAsString()
-
   val jirafeeds = "/whisk.system/jira/jirafeed"
 
   "Jira Package" should "print the webhook created on JIRA" in {

--- a/tests/src/test/scala/packages/jira/JiraTest.scala
+++ b/tests/src/test/scala/packages/jira/JiraTest.scala
@@ -31,14 +31,15 @@ class JiraTests extends TestHelpers with WskTestHelpers with BeforeAndAfterAll {
   implicit val wskprops = WskProps()
   val wsk = new Wsk()
 
-  val credentials = TestUtils.getCredentials("jira_webhook")
-  val username = credentials.get("username").getAsString()
-  val siteName = credentials.get("siteName").getAsString()
-  val accessToken = credentials.get("accessToken").getAsString()
-  val webhookName = credentials.get("webhookName").getAsString()
-  val force_http = credentials.get("force_http").getAsString()
-  val triggerName = "/_/" + credentials.get("triggerName").getAsString()
-  val events = credentials.get("events").getAsString()
+  val credentials = TestUtils.getVCAPcredentials("jira_webhook")
+
+  val username = credentials.get("username")
+  val siteName = credentials.get("siteName")
+  val accessToken = credentials.get("accessToken")
+  val webhookName = credentials.get("webhookName")
+  val force_http = credentials.get("force_http")
+  val triggerName = "/_/" + credentials.get("triggerName")
+  val events = credentials.get("events")
   val jirafeeds = "/whisk.system/jira/jirafeed"
 
   "Jira Package" should "print the webhook created on JIRA" in {

--- a/tests/src/test/scala/packages/jira/JiraTest.scala
+++ b/tests/src/test/scala/packages/jira/JiraTest.scala
@@ -57,7 +57,7 @@ class JiraTests extends TestHelpers with WskTestHelpers with BeforeAndAfterAll {
       activation =>
         activation.response.success shouldBe true
         val logs = activation.logs.get.toString
-        logs should include("Webhook created successfully")
+        logs should include("Status code: 201")
     }
   }
 
@@ -75,7 +75,7 @@ class JiraTests extends TestHelpers with WskTestHelpers with BeforeAndAfterAll {
       activation =>
         activation.response.success shouldBe true
         val logs = activation.logs.get.toString
-        logs should include("Webhook deleted successfully")
+        logs should include("Status code: 204")
     }
   }
 

--- a/tests/src/test/scala/packages/jira/JiraTest.scala
+++ b/tests/src/test/scala/packages/jira/JiraTest.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 
 package packages.jira
 

--- a/tests/src/test/scala/packages/jira/JiraTest.scala
+++ b/tests/src/test/scala/packages/jira/JiraTest.scala
@@ -1,5 +1,5 @@
 
-package packages.slack
+package packages.jira
 
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterAll
@@ -13,23 +13,28 @@ class JiraTests extends TestHelpers with WskTestHelpers with BeforeAndAfterAll {
   implicit val wskprops = WskProps()
   val wsk = new Wsk()
 
-  val credentials = TestUtils.getCredentials("slack_webhook")
+  val credentials = TestUtils.getCredentials("jira_webhook")
   val username = credentials.get("username").getAsString()
   val siteName = credentials.get("siteName").getAsString()
   val accessToken = credentials.get("accessToken").getAsString()
   val webhookName = credentials.get("webhookName").getAsString()
   val force_http = credentials.get("force_http").getAsString()
-  val events = credentials.get("events").getAsString().split(',') //split this
-  val myJiraFeed = credentials.get("channel").getAsString()
+  val triggerName = "/_/" + credentials.get("triggerName").getAsString()
+  val events = credentials.get("events").getAsString()
+
+  val jirafeeds = "/whisk.system/jira/jirafeed"
 
   "Jira Package" should "print the webhook created on JIRA" in {
-    val run = wsk.trigger.create(myJiraFeed, Map(
+    val run = wsk.action.invoke(jirafeeds, Map(
       "username" -> username.toJson,
       "siteName" -> siteName.toJson,
       "accessToken" -> accessToken.toJson,
       "webhookName" -> webhookName.toJson,
       "force_http" -> force_http.toJson,
-      "events" -> events.split(,)toJson))   //can be a syntax error
+      "triggerName" -> triggerName.toJson,
+      "lifecycleEvent" -> "CREATE".toJson,
+      "events" -> events.toJson))
+
     withActivation(wsk.activation, run) {
       activation =>
         activation.response.success shouldBe true
@@ -39,13 +44,15 @@ class JiraTests extends TestHelpers with WskTestHelpers with BeforeAndAfterAll {
   }
 
   "Jira Package" should "print the webhook deleted on JIRA" in {
-    val run = wsk.trigger.delete(myJiraTrigger, Map(
+    val run = wsk.action.invoke(jirafeeds, Map(
       "username" -> username.toJson,
       "siteName" -> siteName.toJson,
       "accessToken" -> accessToken.toJson,
-      //        "webhookName" -> webhookName.toJson,
-      "force_http" -> force_http.toJson))
-    //        "events" -> events.toJson))                       //this should be splitted
+      "webhookName" -> webhookName.toJson,
+      "force_http" -> force_http.toJson,
+      "triggerName" -> triggerName.toJson,
+      "lifecycleEvent" -> "DELETE".toJson,
+      "events" -> events.toJson))
     withActivation(wsk.activation, run) {
       activation =>
         activation.response.success shouldBe true


### PR DESCRIPTION
This can be used to access the JIRA APIs (similar to the github package in the catalog)
These are the lifecycle events that I have defined in my package.

 >> CREATE Lifrecycle Event
      -This event occurs when we create the trigger in /whisk.system/ This creates a webhook in JIRA and register the webhook endpoint to the trigger url along with some auth information.
      -We can pass 'the event types of our interest' as parameters when creating the trigger. Then the JIRA API will fire the trigger bound to that webhook when one of those events occurred in JIRA (example events: creating new issue, creating new project, assigning an issue to a member).
      -We can set a rule to connect a whisk action with this trigger so, the action will be invoked when the trigger is fired.

>> DELETE Lifecycle Event
      -This occures when we delete the trigger from /whisk.system/ The package will look for the webhook which is bound with trigger and delete the relevant webhook from JIRA.
 