### PR TITLE
port websocket package to nodejs:10

### DIFF
--- a/packages/installCatalogUsingWskdeploy.sh
+++ b/packages/installCatalogUsingWskdeploy.sh
@@ -31,6 +31,10 @@ source "$SCRIPTDIR/validateParameter.sh" $1 $2 $3
 
 source "$SCRIPTDIR/util.sh"
 
+echo building OpenWhisk packages
+
+pushd "$SCRIPTDIR/websocket/" && ./build.sh && popd
+
 echo Installing OpenWhisk packages
 
 deployProject "$SCRIPTDIR/github/"

--- a/packages/websocket/.gitignore
+++ b/packages/websocket/.gitignore
@@ -1,0 +1,3 @@
+send.zip
+package-lock.json
+

--- a/packages/websocket/build.sh
+++ b/packages/websocket/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+npm install
+zip -r send.zip *

--- a/packages/websocket/manifest.yaml
+++ b/packages/websocket/manifest.yaml
@@ -33,8 +33,8 @@ project:
             actions:
                 send:
                     version: 0.0.1
-                    function: sendWebSocketMessageAction.js
-                    runtime: nodejs:6
+                    function: send.zip
+                    runtime: nodejs:default
                     annotations:
                         description: "Send a message to a WebSocket"
                         parameters: [

--- a/packages/websocket/package.json
+++ b/packages/websocket/package.json
@@ -1,0 +1,6 @@
+{
+    "main": "sendWebSocketMessageAction.js",
+    "dependencies": {
+        "ws": "7.2.1"
+    }
+}

--- a/packages/websocket/sendWebSocketMessageAction.js
+++ b/packages/websocket/sendWebSocketMessageAction.js
@@ -79,3 +79,5 @@ function main(params) {
 
     return promise;
 }
+
+exports.main = main;


### PR DESCRIPTION
add package/build logic to enable websockets package to use nodejs:10
runtime kind (which unlike nodejs:6 does not bundle the ws package).

Fixes #294 